### PR TITLE
Update processor.php to list categories in e-mails

### DIFF
--- a/classes/processor.php
+++ b/classes/processor.php
@@ -1261,7 +1261,7 @@ class tool_coursearchiver_processor {
               id,
               name AS CatPath 
             FROM {course_categories}
-            WHERE parent = 0 -- Top-level managers who have no managers
+            WHERE parent = 0 -- Top-level categories
             
             UNION ALL
             
@@ -1269,7 +1269,7 @@ class tool_coursearchiver_processor {
               e.id,
               Concat(oc.CatPath,' -> ',e.name) 
             FROM {course_categories} e
-            JOIN CatPaths oc ON e.parent = oc.id -- Join on manager_id to find the next level manager
+            JOIN CatPaths oc ON e.parent = oc.id -- Join on parent_id to find the next subcat
           )
           SELECT * FROM CatPaths";
         $return  = $DB->get_records_sql_menu($sql, $params);


### PR DESCRIPTION
In emails a path of the category, where the course resides, is added before course name, for easier distinguishing and finding similar short named courses. eg:
"2024 -> Biology -> Molecular Biology: IntroMolBiol24" 
"2023 -> Biology -> Molecular Biology: IntroMolBiol23"

Due to the new SQL, which uses
`WITH RECURSIVE...`
I think this is only working with newer versions (8+) of MySQL, MariaDB

Todo: (suggestions)
- add option to Show/not show category path in settings
- make hard-coded path separator ("->") user-definable in settings (eg. "/" " - ")

